### PR TITLE
Use POST request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,12 @@ tag:
 	git commit -m "Release: v$(VERSION)"
 	git tag v$(VERSION)
 
+# quick way to check if it really works
+integration_test: build
+	./gotr en en foo > test.file
+	test $$(cat test.file) = 'foo'
+	rm test.file
+
 build_all:
 	mkdir -p bin
 	@for goos in linux windows darwin ; do \

--- a/googletranslate/request_builder.go
+++ b/googletranslate/request_builder.go
@@ -21,7 +21,7 @@ func runRquest(urlString string, params map[string]string) (resp *http.Response,
 
 	urlObj.RawQuery = v.Encode()
 
-	req, err := http.NewRequest("GET", urlObj.String(), nil)
+	req, err := http.NewRequest("POST", urlObj.String(), nil)
 	check(err)
 
 	req.Header.Add("User-Agent", "Mozilla/5.0")


### PR DESCRIPTION
Google started filtering out GET requests.

This is a quick fix. Will need to add more tests, and improve logging.